### PR TITLE
Adding error check during json formatting to return proper error content

### DIFF
--- a/src/AspNetCore.Hateoas/Formatters/JsonHateoasFormatter.cs
+++ b/src/AspNetCore.Hateoas/Formatters/JsonHateoasFormatter.cs
@@ -45,6 +45,14 @@ namespace AspNetCore.Hateoas.Formatters
             };
 
             var resource = default(Resource);
+            
+            if (context.Object is SerializableError error)
+            {
+                var errorOutput = JsonConvert.SerializeObject(error, serializerSettings);
+                response.ContentType = "application/json";
+                return response.WriteAsync(errorOutput);
+            }
+            
             var result = context.Object;
 
             if (context.ObjectType.GetInterfaces().Contains(typeof(IEnumerable)))


### PR DESCRIPTION
This PR is intended to fix #3.

**Solution**
We should check result object whether it is error or not. Otherwise it will fail during resource creation phase.