### PR TITLE
Added .net core 3 compatibility

### DIFF
--- a/src/AspNetCore.Hateoas/AspNetCore.Hateoas.csproj
+++ b/src/AspNetCore.Hateoas/AspNetCore.Hateoas.csproj
@@ -1,13 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageVersion>1.0.3</PackageVersion>
+    <TargetFrameworks>netcoreapp3.0; netstandard2.0</TargetFrameworks>
+    <PackageVersion>1.1.0</PackageVersion>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup>     
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />    
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/AspNetCore.Hateoas/Formatters/JsonHateoasFormatter.cs
+++ b/src/AspNetCore.Hateoas/Formatters/JsonHateoasFormatter.cs
@@ -2,9 +2,13 @@
 using AspNetCore.Hateoas.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+#if NETCOREAPP3_0
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+#elif NETSTANDARD2_0
+    using Microsoft.AspNetCore.Mvc.Internal;
+#endif
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
-using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;

--- a/src/AspNetCore.Hateoas/Formatters/JsonHateoasFormatter.cs
+++ b/src/AspNetCore.Hateoas/Formatters/JsonHateoasFormatter.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 #if NETCOREAPP3_0
 using Microsoft.AspNetCore.Mvc.ActionConstraints;
 #elif NETSTANDARD2_0
-    using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Mvc.Internal;
 #endif
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Infrastructure;


### PR DESCRIPTION
The current solution doesn't work for applications targeting .Net Core 3.0.  

HttpMethodActionConstraint in particular is causing issues with netcoreapp3.0. 

With netcoreapp3.0 it should be using `Microsoft.AspNetCore.Mvc.ActionConstraints` where with netstandard2.0 it should use using `Microsoft.AspNetCore.Mvc.Internal`;